### PR TITLE
fix: use Django Python API to make projects and apps

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -114,10 +114,12 @@ def main() -> None:
         os.mkdir(app_directory)
     except FileExistsError:
         print("error: app folder could not be made as it already exists")
+        return
     except FileNotFoundError:
         print(
             "error: app folder could not be made as its parent directory doesn't exist"
         )
+        return
 
     try:
         call_command("startapp", args.app_name, app_directory)


### PR DESCRIPTION
Changed the way projects and apps are created to use the Django Python API, rather than using the command line tools called from a Python `subprocess`.

Closes #18 