### PR TITLE
feat: make project generation optional

### DIFF
--- a/src/openapi_to_django/command_line.py
+++ b/src/openapi_to_django/command_line.py
@@ -20,7 +20,7 @@ FILE_MODE = "files"
 
 
 def main() -> None:
-    """Load a given OpenAPI document into a new Django project and app."""
+    """Load a given OpenAPI document with an ArgumentParser and generate Django code."""
     parser = create_parser()
     args = validate_args(parser.parse_args())
 


### PR DESCRIPTION
Add additional command line arguments to make the creation of Django projects optional. Users may wish to just generate URLs and views files without the surrounding Django project.

Create the `projects` and `files` subparsers, with the former allowing users to create Django projects with the rendered files contained within them (quicker to get started), and the latter generating just the rendered URLs and views files. The arguments for each subparser are based on their use cases, such as the project and app names being excluded from the `files` subparser.

Closes #36 