### PR TITLE
ci: create draft release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,6 @@ jobs:
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Content-Type: application/octet-stream" \
-            "$base_upload_url?$name=test" \
+            "$base_upload_url?name=$package" \
             --data-binary "@dist/$package";
           done


### PR DESCRIPTION
Create a GitHub Actions pipeline to automatically create a release when the repository is tagged with a version (v*.*.*). The Python packages are built and uploaded as assets for the release.

Closes #40 