### PR TITLE
ci: increase verbosity of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,9 @@
 
 name: Publish to TestPyPI
 
-on: push
-  # release:
-  #   types: [published]
+on:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openapi_to_django"
-version = "100.0.0"
+version = "0.1.0"
 description = "Generate Django code from OpenAPI documents."
 authors = [
     { name = "jaytik1" }


### PR DESCRIPTION
Increase verbosity of the publish workflow so any future bugs when pushing to TestPyPI (and eventually PyPI) can be more easily identified. This helped solve #43 by identifying the reason for TestPyPI returning a 400 response, which was due to the file names already existing.

Closes: #43 